### PR TITLE
No auth errors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
-set -euxo pipefail
+set -euo pipefail
 
+# ensure binaries needed for building exist
+which go > /dev/null
+which bzr > /dev/null
+which tsc > /dev/null
 
 LDFLAGS="-X bosun.org/_version.VersionSHA=$(git rev-parse HEAD) -X bosun.org/_version.VersionDate=$(date -u "+%Y%m%d%H%M%S")"
 

--- a/cmd/bosun/web/static/js/bosun.js
+++ b/cmd/bosun/web/static/js/bosun.js
@@ -1,7 +1,7 @@
 /// <reference path="moment.d.ts" />
 /// <reference path="moment-duration-format.d.ts" />
 //Represents an auth token
-var Token = (function () {
+var Token = /** @class */ (function () {
     function Token() {
         this.Description = "";
         this.Role = 0;
@@ -10,19 +10,19 @@ var Token = (function () {
     return Token;
 }());
 //metadata about a single role or permission
-var BitMeta = (function () {
+var BitMeta = /** @class */ (function () {
     function BitMeta() {
     }
     return BitMeta;
 }());
 //all roles/permissions for bosun
-var RoleDefs = (function () {
+var RoleDefs = /** @class */ (function () {
     function RoleDefs() {
     }
     return RoleDefs;
 }());
 // See models/incident.go Event (can't be event here because JS uses that)
-var IncidentEvent = (function () {
+var IncidentEvent = /** @class */ (function () {
     function IncidentEvent(ie) {
         this.Value = ie.Value;
         this.Expr = ie.Expr;
@@ -32,7 +32,7 @@ var IncidentEvent = (function () {
     }
     return IncidentEvent;
 }());
-var Annotation = (function () {
+var Annotation = /** @class */ (function () {
     function Annotation(a, get) {
         a = a || {};
         this.Id = a.Id || "";
@@ -58,14 +58,14 @@ var Annotation = (function () {
     };
     return Annotation;
 }());
-var Result = (function () {
+var Result = /** @class */ (function () {
     function Result(r) {
         this.Value = r.Value;
         this.Expr = r.Expr;
     }
     return Result;
 }());
-var Action = (function () {
+var Action = /** @class */ (function () {
     function Action(a) {
         this.User = a.User;
         this.Message = a.Message;
@@ -78,7 +78,7 @@ var Action = (function () {
     return Action;
 }());
 // See models/incident.go
-var IncidentState = (function () {
+var IncidentState = /** @class */ (function () {
     function IncidentState(is) {
         this.Id = is.Id;
         this.Start = is.Start;
@@ -130,7 +130,7 @@ var IncidentState = (function () {
     };
     return IncidentState;
 }());
-var StateGroup = (function () {
+var StateGroup = /** @class */ (function () {
     function StateGroup(sg) {
         this.Active = sg.Active;
         this.Status = sg.Status;
@@ -154,7 +154,7 @@ var StateGroup = (function () {
     }
     return StateGroup;
 }());
-var Groups = (function () {
+var Groups = /** @class */ (function () {
     function Groups(g) {
         this.NeedAck = new Array();
         if (g.NeedAck) {
@@ -173,7 +173,7 @@ var Groups = (function () {
     }
     return Groups;
 }());
-var StateGroups = (function () {
+var StateGroups = /** @class */ (function () {
     function StateGroups(sgs) {
         this.Groups = new Groups(sgs.Groups);
         this.TimeAndDate = sgs.TimeAndDate;
@@ -817,7 +817,7 @@ bosunControllers.controller('AnnotationCtrl', ['$scope', '$http', '$location', '
         };
     }]);
 /// <reference path="0-bosun.ts" />
-var AuthService = (function () {
+var AuthService = /** @class */ (function () {
     function AuthService() {
     }
     AuthService.prototype.Init = function (authEnabled, username, roles, userPerms) {
@@ -903,7 +903,7 @@ var AuthService = (function () {
 }());
 bosunApp.service("authService", AuthService);
 //simple component to show a <username-input> easily
-var UsernameInputController = (function () {
+var UsernameInputController = /** @class */ (function () {
     function UsernameInputController(auth) {
         this.auth = auth;
     }
@@ -1238,7 +1238,7 @@ bosunControllers.controller('ConfigCtrl', ['$scope', '$http', '$location', '$rou
             if (diff == 0) {
                 intervals = 1;
             }
-            else if (Math.abs(diff) < 60 * 1000) {
+            else if (Math.abs(diff) < 60 * 1000) { // 1 minute
                 intervals = 2;
             }
             else {
@@ -1389,7 +1389,7 @@ bosunControllers.controller('ConfigCtrl', ['$scope', '$http', '$location', '$rou
         };
         return $scope;
     }]);
-var NotificationController = (function () {
+var NotificationController = /** @class */ (function () {
     function NotificationController($http) {
         var _this = this;
         this.$http = $http;
@@ -1595,14 +1595,14 @@ bosunApp.directive('tsTab', function () {
                     return;
                 }
                 switch (evt.keyCode) {
-                    case 9:// tab
+                    case 9: // tab
                         evt.preventDefault();
                         var v = ta.value;
                         var start = ta.selectionStart;
                         ta.value = v.substr(0, start) + "\t" + v.substr(start);
                         ta.selectionStart = ta.selectionEnd = start + 1;
                         return;
-                    case 13:// enter
+                    case 13: // enter
                         if (ta.selectionStart != ta.selectionEnd) {
                             return;
                         }
@@ -1974,11 +1974,11 @@ bosunApp.directive('tsGraph', ['$window', 'nfmtFilter', function ($window, fmtfi
                 annotateEnabled: '=',
                 showAnnotations: '='
             },
-            template: '<div class="row"></div>' +
-                '<div class="row col-lg-12"></div>' +
-                '<div class"row">' +
-                '<div class="col-lg-6"></div>' +
-                '<div class="col-lg-6"></div>' +
+            template: '<div class="row"></div>' + // chartElemt
+                '<div class="row col-lg-12"></div>' + // timeElem
+                '<div class"row">' + // legendAnnContainer
+                '<div class="col-lg-6"></div>' + // legendElem
+                '<div class="col-lg-6"></div>' + // annElem
                 '</div>',
             link: function (scope, elem, attrs, $compile) {
                 var chartElem = d3.select(elem.children()[0]);
@@ -2547,22 +2547,22 @@ bosunControllers.controller('ErrorCtrl', ['$scope', '$http', '$location', '$rout
         };
     }]);
 /// <reference path="0-bosun.ts" />
-var TagSet = (function () {
+var TagSet = /** @class */ (function () {
     function TagSet() {
     }
     return TagSet;
 }());
-var TagV = (function () {
+var TagV = /** @class */ (function () {
     function TagV() {
     }
     return TagV;
 }());
-var RateOptions = (function () {
+var RateOptions = /** @class */ (function () {
     function RateOptions() {
     }
     return RateOptions;
 }());
-var Filter = (function () {
+var Filter = /** @class */ (function () {
     function Filter(f) {
         this.type = f && f.type || "auto";
         this.tagk = f && f.tagk || "";
@@ -2571,12 +2571,12 @@ var Filter = (function () {
     }
     return Filter;
 }());
-var FilterMap = (function () {
+var FilterMap = /** @class */ (function () {
     function FilterMap() {
     }
     return FilterMap;
 }());
-var Query = (function () {
+var Query = /** @class */ (function () {
     function Query(filterSupport, q) {
         this.aggregator = q && q.aggregator || 'sum';
         this.metric = q && q.metric || '';
@@ -2674,7 +2674,7 @@ var Query = (function () {
     };
     return Query;
 }());
-var GraphRequest = (function () {
+var GraphRequest = /** @class */ (function () {
     function GraphRequest() {
         this.start = '1h-ago';
         this.queries = [];
@@ -2707,7 +2707,7 @@ var GraphRequest = (function () {
     return GraphRequest;
 }());
 var graphRefresh;
-var Version = (function () {
+var Version = /** @class */ (function () {
     function Version() {
     }
     return Version;
@@ -3398,7 +3398,7 @@ bosunControllers.controller('ItemsCtrl', ['$scope', '$http', function ($scope, $
         });
     }]);
 /// <reference path="0-bosun.ts" />
-var LinkService = (function () {
+var LinkService = /** @class */ (function () {
     function LinkService() {
     }
     LinkService.prototype.GetEditSilenceLink = function (silence, silenceId) {
@@ -3420,12 +3420,12 @@ var LinkService = (function () {
     return LinkService;
 }());
 bosunApp.service("linkService", LinkService);
-var Tag = (function () {
+var Tag = /** @class */ (function () {
     function Tag() {
     }
     return Tag;
 }());
-var DP = (function () {
+var DP = /** @class */ (function () {
     function DP() {
     }
     return DP;
@@ -3858,7 +3858,7 @@ bosunApp.directive('tsForceClose', function () {
     };
 });
 /// <reference path="0-bosun.ts" />
-var TokenListController = (function () {
+var TokenListController = /** @class */ (function () {
     function TokenListController($http, auth) {
         var _this = this;
         this.$http = $http;
@@ -3911,7 +3911,7 @@ bosunApp.component('tokenList', {
     templateUrl: '/static/partials/tokenList.html'
 });
 /// <reference path="0-bosun.ts" />
-var NewTokenController = (function () {
+var NewTokenController = /** @class */ (function () {
     function NewTokenController($http, auth) {
         var _this = this;
         this.$http = $http;

--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -149,7 +149,7 @@ func Listen(httpAddr, httpsAddr, certFile, keyFile string, devMode bool, tsdbHos
 	}
 
 	handle("/api/egraph/{bs}.{format:svg|png}", JSON(ExprGraph), canRunTests).Name("expr_graph")
-	handle("/api/errors", JSON(ErrorHistory), canViewDash).Name("errors").Methods(GET, POST)
+	handle("/api/errors", JSON(ErrorHistory), fullyOpen).Name("errors").Methods(GET, POST)
 	handle("/api/expr", JSON(Expr), canRunTests).Name("expr").Methods(POST)
 	handle("/api/graph", JSON(Graph), canViewDash).Name("graph").Methods(GET)
 


### PR DESCRIPTION
Allow access to error history without auth.
Also fix up build script slightly and add in typescript fixes.

Example run:
```
dist/bosun -c ~/github/bosun/bosun.toml 
2020/04/29 09:01:31 enabling syslog
2020/04/29 09:01:31 info: migrate.go:138: checking migrations
2020/04/29 09:01:31 info: migrate.go:150: schema version not found in db
2020/04/29 09:01:31 info: migrate.go:152: assuming new installation because allIncidents key not found
2020/04/29 09:01:31 info: migrate.go:153: writing current schema version
2020/04/29 09:01:31 info: search.go:208: Loading last datapoints from redis
2020/04/29 09:01:31 error: search.go:211: search_data.go:189: redigo: nil returned
2020/04/29 09:01:31 info: search.go:215: Done
2020/04/29 09:01:31 info: web.go:216: tsdb host: 
2020/04/29 09:01:31 info: web.go:220: bosun web listening http on: :8080
```
```
curl localhost:8080/api/errors
{}
```