### PR TITLE
Keep silence ids on the object

### DIFF
--- a/cmd/bosun/database/silence_data.go
+++ b/cmd/bosun/database/silence_data.go
@@ -84,6 +84,7 @@ func (d *dataAccess) getSilences(ids []string, conn redis.Conn) ([]*models.Silen
 				return nil, err
 			}
 		}
+		s.CachedId = ids[idx]
 		silences = append(silences, s)
 	}
 	return silences, nil

--- a/models/silence.go
+++ b/models/silence.go
@@ -17,6 +17,7 @@ type Silence struct {
 	Forget     bool
 	User       string
 	Message    string
+	CachedId   string `json:"-"`
 }
 
 func (s *Silence) Silenced(now time.Time, alert string, tags opentsdb.TagSet) bool {
@@ -51,7 +52,12 @@ func (s *Silence) Matches(alert string, tags opentsdb.TagSet) bool {
 }
 
 func (s Silence) ID() string {
+	if s.CachedId != "" {
+		return s.CachedId
+	}
 	h := sha1.New()
 	fmt.Fprintf(h, "%s|%s|%s%s", s.Start, s.End, s.Alert, s.Tags)
-	return fmt.Sprintf("%x", h.Sum(nil))
+	id := fmt.Sprintf("%x", h.Sum(nil))
+	s.CachedId = id
+	return id
 }


### PR DESCRIPTION
Bosun does something stupid and generates redis ids based on the SHA1 hash of
the start and end times (both parsed from a human-readable, rounded string), the
alert name, and the tag set (an unordered hash map). This causes some silences
to return with different IDs than they really are, causing deletes to not work.

With this change, the silence object keeps the ID as a string.